### PR TITLE
Hide user profile posts from private networks

### DIFF
--- a/views/members.ejs
+++ b/views/members.ejs
@@ -61,7 +61,8 @@
                     
                     <div class="buttons buttons-container">
                         <% if(user.id != members[i]._id) { %>
-                        <a href="/message/<%= members[i].userName %>">
+                        <!-- <a href="/message/<%= members[i].userName %>"> -->
+                        <a href="#">
                         <button class="btn btn-outline-primary px-4"><i class="fa fa-solid fa-envelope"></i></button>
                         </a>
                           <% } %>

--- a/views/partials/post.ejs
+++ b/views/partials/post.ejs
@@ -1,6 +1,6 @@
 <div class="mt-5 hidden" id="postForm">
     <div class="d-flex justify-center">
-      <h2>Add a post</h2>
+      <h2>Write a post</h2>
     </div>
     <% if(network) { %>
         <form action="/post/createPost/<%=network.name%>" enctype="multipart/form-data" method="POST">

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -143,6 +143,9 @@
 
       
                 <% for(let i = 0; i < posts.length; i++) { %>
+                  <% if(hashmapPrivate[posts[i].network]) { %>
+                    <% continue %>
+                  <% } %>
                 <div class="card cardFeed">
                     <div class="d-flex justify-content-between p-2 px-3">
                         <div class="d-flex flex-row align-items-center"> 


### PR DESCRIPTION
Users now cannot see profile posts of other users from private networks, unless they are members of the private networks themselves.